### PR TITLE
Add relative time helper for zone check timestamps

### DIFF
--- a/handler_index.go
+++ b/handler_index.go
@@ -4,13 +4,15 @@ import (
 	"database/sql"
 	"net/http"
 	"strconv"
+	"time"
 )
 
 type domainRow struct {
-	Rank      int
-	Name      string
-	HasDNSSEC bool
-	CheckedAt string
+	Rank          int
+	Name          string
+	HasDNSSEC     bool
+	CheckedAt     string
+	CheckedAtTime time.Time
 }
 
 func indexHandler(db *sql.DB) http.Handler {
@@ -52,6 +54,7 @@ func indexHandler(db *sql.DB) http.Handler {
 			}
 			rec.HasDNSSEC = sec.Valid && sec.Bool
 			if checked.Valid {
+				rec.CheckedAtTime = checked.Time
 				rec.CheckedAt = checked.Time.Format("2006-01-02 15:04")
 			}
 			list = append(list, rec)

--- a/helpers.go
+++ b/helpers.go
@@ -1,0 +1,29 @@
+package main
+
+import (
+	"fmt"
+	"time"
+)
+
+func relativeTime(t time.Time) string {
+	d := time.Since(t)
+	switch {
+	case d < time.Hour:
+		m := int(d.Minutes())
+		if m <= 1 {
+			return "1 minute ago"
+		}
+		return fmt.Sprintf("%d minutes ago", m)
+	case d < 24*time.Hour:
+		h := int(d.Hours())
+		if h <= 1 {
+			return "1 hour ago"
+		}
+		return fmt.Sprintf("%d hours ago", h)
+	case d < 48*time.Hour:
+		return "yesterday"
+	default:
+		days := int(d.Hours() / 24)
+		return fmt.Sprintf("%d days ago", days)
+	}
+}

--- a/main.go
+++ b/main.go
@@ -18,7 +18,9 @@ var templatesFS embed.FS
 var staticFS embed.FS
 
 var templates = template.Must(
-	template.ParseFS(templatesFS, "templates/*.html"),
+	template.New("").Funcs(template.FuncMap{
+		"relativeTime": relativeTime,
+	}).ParseFS(templatesFS, "templates/*.html"),
 )
 
 func main() {

--- a/templates/index.html
+++ b/templates/index.html
@@ -21,7 +21,9 @@
     <div class="{{ if .HasDNSSEC }}text-red-600 font-bold{{ else }}text-green-200{{ end }}">
       {{ if .HasDNSSEC }}Enabled{{ else }}Disabled{{ end }}
     </div>
-    <div>{{ .CheckedAt }}</div>
+    <div title="{{ .CheckedAt }}">
+      {{ if .CheckedAt }}{{ relativeTime .CheckedAtTime }}{{ end }}
+    </div>
   </div>
   {{ end }}
   <div class="flex justify-between mt-4">


### PR DESCRIPTION
## Summary
- create a `relativeTime` helper in Go to show how long ago zones were checked
- expose helper to templates and use it in the index page
- store `CheckedAtTime` on domain rows

## Testing
- `go vet ./...`
- `go build ./...`
- `npm run build:css`

------
https://chatgpt.com/codex/tasks/task_e_685632ca6fd48332a2983ee88bb92f6d