### PR TITLE
Add DNSSEC adoption percentages to index

### DIFF
--- a/templates/index.html
+++ b/templates/index.html
@@ -8,6 +8,11 @@
 </head>
 <body class="p-4">
   <h1 class="text-2xl mb-4">DNSSEC Status</h1>
+  <div class="mb-4 grid grid-cols-3 gap-4">
+    <div>Top 1000: {{ printf "%.1f" .Pct1000 }}%</div>
+    <div>Top 500: {{ printf "%.1f" .Pct500 }}%</div>
+    <div>Top 100: {{ printf "%.1f" .Pct100 }}%</div>
+  </div>
   <div class="grid grid-cols-4 gap-2 font-bold border-b pb-2">
     <div>Rank</div>
     <div>Domain</div>


### PR DESCRIPTION
## Summary
- calculate DNSSEC adoption ratios for the top 1000, 500 and 100 domains
- show those percentages on the homepage

## Testing
- `go vet ./...`
- `go test ./...`

------
https://chatgpt.com/codex/tasks/task_e_68573a6935e083329077d440b7db7ca8