### PR TITLE
Improve domain list layout

### DIFF
--- a/handler_index.go
+++ b/handler_index.go
@@ -11,6 +11,9 @@ import (
 type domainRow struct {
 	Rank          int
 	Name          string
+	Base          string
+	TLD           string
+	Important     bool
 	HasDNSSEC     bool
 	CheckedAt     string
 	CheckedAtTime time.Time
@@ -72,6 +75,8 @@ func indexHandler(db *sql.DB) http.Handler {
 				http.Error(w, err.Error(), http.StatusInternalServerError)
 				return
 			}
+			rec.Base, rec.TLD = domainParts(rec.Name)
+			rec.Important = isImportantTLD(rec.TLD)
 			rec.HasDNSSEC = sec.Valid && sec.Bool
 			if checked.Valid {
 				rec.CheckedAtTime = checked.Time

--- a/helpers.go
+++ b/helpers.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"fmt"
+	"strings"
 	"time"
 )
 
@@ -26,4 +27,20 @@ func relativeTime(t time.Time) string {
 		days := int(d.Hours() / 24)
 		return fmt.Sprintf("%d d ago", days)
 	}
+}
+
+func domainParts(name string) (string, string) {
+	i := strings.LastIndexByte(name, '.')
+	if i < 0 {
+		return name, ""
+	}
+	return name[:i], name[i+1:]
+}
+
+func isImportantTLD(tld string) bool {
+	switch tld {
+	case "mil", "gov", "eu":
+		return true
+	}
+	return false
 }

--- a/templates/index.html
+++ b/templates/index.html
@@ -26,12 +26,17 @@
   <div class="sm:hidden space-y-2">
     {{ range .Domains }}
     <div class="bg-white p-3 rounded shadow">
-      <p class="text-sm font-semibold">#{{ .Rank }}&nbsp;{{ .Name }}</p>
+      <p class="text-sm">
+        <span class="text-gray-500">#{{ .Rank }}</span>
+        <span class="font-semibold">
+          {{ .Base }}<span class="{{ if .Important }}text-red-600{{ else }}text-gray-400{{ end }}">.{{ .TLD }}</span>
+        </span>
+      </p>
       <p class="text-xs text-gray-500">
         {{ if .HasDNSSEC }}
         <span class="inline-flex items-center px-2 py-0.5 rounded-full text-xs font-medium bg-red-100 text-red-600">enabled</span>
         {{ else }}
-        <span class="inline-flex items-center px-2 py-0.5 rounded-full text-xs font-medium bg-gray-100 text-gray-500">disabled</span>
+        <span class="text-gray-400">disabled</span>
         {{ end }}
         &bull;
         {{ if .CheckedAt }}{{ relativeTime .CheckedAtTime }}{{ end }}
@@ -43,6 +48,7 @@
   <table class="hidden sm:table w-full text-sm">
     <thead class="bg-gray-100 sticky top-0">
       <tr>
+        <th class="px-2 py-1 text-left w-12">#</th>
         <th class="px-2 py-1 text-left">Domain</th>
         <th class="px-2 py-1 text-left">Status</th>
         <th class="px-2 py-1 text-left">Checked</th>
@@ -51,12 +57,15 @@
     <tbody>
       {{ range .Domains }}
       <tr class="even:bg-gray-50 hover:bg-gray-100">
-        <td class="px-2 py-1 font-semibold">#{{ .Rank }} {{ .Name }}</td>
+        <td class="px-2 py-1 text-gray-500">#{{ .Rank }}</td>
+        <td class="px-2 py-1 font-semibold">
+          {{ .Base }}<span class="{{ if .Important }}text-red-600{{ else }}text-gray-400{{ end }}">.{{ .TLD }}</span>
+        </td>
         <td class="px-2 py-1">
           {{ if .HasDNSSEC }}
           <span class="inline-flex items-center px-2 py-0.5 rounded-full text-xs font-medium bg-red-100 text-red-600">enabled</span>
           {{ else }}
-          <span class="inline-flex items-center px-2 py-0.5 rounded-full text-xs font-medium bg-gray-100 text-gray-500">disabled</span>
+          <span class="text-gray-400">disabled</span>
           {{ end }}
         </td>
         <td class="px-2 py-1" title="{{ .CheckedAt }}">


### PR DESCRIPTION
## Summary
- parse domain/TLD and mark government or EU zones
- separate rank from domain in the table
- tone down the disabled state

## Testing
- `go build ./...`
- `npm run build:css`

------
https://chatgpt.com/codex/tasks/task_e_6857432453608332968947dcf7f72f65