### PR TITLE
Update dashboard header and links

### DIFF
--- a/templates/index.html
+++ b/templates/index.html
@@ -7,19 +7,26 @@
   <link href="/static/style.css" rel="stylesheet">
 </head>
 <body class="p-4">
-  <h1 class="text-2xl mb-4">DNSSEC Status</h1>
+  <h1 class="text-2xl mb-2">DNSSEC Status</h1>
+  <p class="mb-4"></p>
   <div class="mb-4 grid grid-cols-1 sm:grid-cols-3 gap-4">
-    <div class="bg-white shadow rounded-lg p-4 text-center">
-      <div class="text-xs font-semibold text-gray-500 uppercase">Top 1000</div>
-      <div class="text-2xl font-bold">{{ printf "%.1f" .Pct1000 }}%</div>
-    </div>
-    <div class="bg-white shadow rounded-lg p-4 text-center">
-      <div class="text-xs font-semibold text-gray-500 uppercase">Top 500</div>
-      <div class="text-2xl font-bold">{{ printf "%.1f" .Pct500 }}%</div>
-    </div>
     <div class="bg-white shadow rounded-lg p-4 text-center">
       <div class="text-xs font-semibold text-gray-500 uppercase">Top 100</div>
       <div class="text-2xl font-bold">{{ printf "%.1f" .Pct100 }}%</div>
+    </div>
+    <div class="bg-white shadow rounded-lg p-4 text-center">
+      <a
+        href="/?page=3"
+        class="text-xs font-semibold text-gray-500 uppercase no-underline hover:underline"
+      >Top 500</a>
+      <div class="text-2xl font-bold">{{ printf "%.1f" .Pct500 }}%</div>
+    </div>
+    <div class="bg-white shadow rounded-lg p-4 text-center">
+      <a
+        href="/?page=11"
+        class="text-xs font-semibold text-gray-500 uppercase no-underline hover:underline"
+      >Top 1000</a>
+      <div class="text-2xl font-bold">{{ printf "%.1f" .Pct1000 }}%</div>
     </div>
   </div>
 

--- a/templates/index.html
+++ b/templates/index.html
@@ -1,95 +1,116 @@
 {{ define "index" }}
 <!doctype html>
 <html>
-<head>
-  <meta charset="utf-8">
-  <title>dnssecme-not</title>
-  <link href="/static/style.css" rel="stylesheet">
-</head>
-<body class="p-4">
-  <h1 class="text-2xl mb-2">DNSSEC Status</h1>
-  <p class="mb-4"></p>
-  <div class="mb-4 grid grid-cols-1 sm:grid-cols-3 gap-4">
-    <div class="bg-white shadow rounded-lg p-4 text-center">
-      <div class="text-xs font-semibold text-gray-500 uppercase">Top 100</div>
-      <div class="text-2xl font-bold">{{ printf "%.1f" .Pct100 }}%</div>
-    </div>
-    <div class="bg-white shadow rounded-lg p-4 text-center">
-      <a
-        href="/?page=3"
-        class="text-xs font-semibold text-gray-500 uppercase no-underline hover:underline"
-      >Top 500</a>
-      <div class="text-2xl font-bold">{{ printf "%.1f" .Pct500 }}%</div>
-    </div>
-    <div class="bg-white shadow rounded-lg p-4 text-center">
-      <a
-        href="/?page=11"
-        class="text-xs font-semibold text-gray-500 uppercase no-underline hover:underline"
-      >Top 1000</a>
-      <div class="text-2xl font-bold">{{ printf "%.1f" .Pct1000 }}%</div>
-    </div>
-  </div>
+    <head>
+        <meta charset="utf-8" />
+        <title>dnssec-me-not: tracking DNSSEC adoption in top domains</title>
+        <link href="/static/style.css" rel="stylesheet" />
+    </head>
+    <body class="p-4">
+        <h1 class="text-2xl mb-2">DNSSEC Adoption In The Tranco Top 1000</h1>
+        <p class="mb-4"></p>
+        <div class="mb-4 grid grid-cols-1 sm:grid-cols-3 gap-4">
+            <div class="bg-white shadow rounded-lg p-4 text-center">
+                <div class="text-xs font-semibold text-gray-500 uppercase">
+                    Top 100
+                </div>
+                <div class="text-2xl font-bold">
+                    {{ printf "%.1f" .Pct100 }}%
+                </div>
+            </div>
+            <div class="bg-white shadow rounded-lg p-4 text-center">
+                <a
+                    href="/?page=3"
+                    class="text-xs font-semibold text-gray-500 uppercase no-underline hover:underline"
+                    >Top 500</a
+                >
+                <div class="text-2xl font-bold">
+                    {{ printf "%.1f" .Pct500 }}%
+                </div>
+            </div>
+            <div class="bg-white shadow rounded-lg p-4 text-center">
+                <a
+                    href="/?page=11"
+                    class="text-xs font-semibold text-gray-500 uppercase no-underline hover:underline"
+                    >Top 1000</a
+                >
+                <div class="text-2xl font-bold">
+                    {{ printf "%.1f" .Pct1000 }}%
+                </div>
+            </div>
+        </div>
 
-  <div class="sm:hidden space-y-2">
-    {{ range .Domains }}
-    <div class="bg-white p-3 rounded shadow">
-      <p class="text-sm">
-        <span class="text-gray-500">#{{ .Rank }}</span>
-        <span class="font-semibold">
-          {{ .Base }}<span class="{{ if .Important }}text-red-600{{ else }}text-gray-400{{ end }}">.{{ .TLD }}</span>
-        </span>
-      </p>
-      <p class="text-xs text-gray-500">
-        {{ if .HasDNSSEC }}
-        <span class="inline-flex items-center px-2 py-0.5 rounded-full text-xs font-medium bg-red-100 text-red-600">enabled</span>
-        {{ else }}
-        <span class="text-gray-400">disabled</span>
-        {{ end }}
-        &bull;
-        {{ if .CheckedAt }}{{ relativeTime .CheckedAtTime }}{{ end }}
-      </p>
-    </div>
-    {{ end }}
-  </div>
+        <div class="sm:hidden space-y-2">
+            {{ range .Domains }}
+            <div class="bg-white p-3 rounded shadow">
+                <p class="text-sm">
+                    <span class="text-gray-500">#{{ .Rank }}</span>
+                    <span class="font-semibold">
+                        {{ .Base }}<span
+                            class="{{ if .Important }}text-red-600{{ else }}text-gray-400{{ end }}"
+                            >.{{ .TLD }}</span
+                        >
+                    </span>
+                </p>
+                <p class="text-xs text-gray-500">
+                    {{ if .HasDNSSEC }}
+                    <span
+                        class="inline-flex items-center px-2 py-0.5 rounded-full text-xs font-medium bg-red-100 text-red-600"
+                        >enabled</span
+                    >
+                    {{ else }}
+                    <span class="text-gray-400">disabled</span>
+                    {{ end }} &bull; {{ if .CheckedAt }}{{ relativeTime
+                    .CheckedAtTime }}{{ end }}
+                </p>
+            </div>
+            {{ end }}
+        </div>
 
-  <table class="hidden sm:table w-full text-sm">
-    <thead class="bg-gray-100 sticky top-0">
-      <tr>
-        <th class="px-2 py-1 text-left w-12">#</th>
-        <th class="px-2 py-1 text-left">Domain</th>
-        <th class="px-2 py-1 text-left">Status</th>
-        <th class="px-2 py-1 text-left">Checked</th>
-      </tr>
-    </thead>
-    <tbody>
-      {{ range .Domains }}
-      <tr class="even:bg-gray-50 hover:bg-gray-100">
-        <td class="px-2 py-1 text-gray-500">#{{ .Rank }}</td>
-        <td class="px-2 py-1 font-semibold">
-          {{ .Base }}<span class="{{ if .Important }}text-red-600{{ else }}text-gray-400{{ end }}">.{{ .TLD }}</span>
-        </td>
-        <td class="px-2 py-1">
-          {{ if .HasDNSSEC }}
-          <span class="inline-flex items-center px-2 py-0.5 rounded-full text-xs font-medium bg-red-100 text-red-600">enabled</span>
-          {{ else }}
-          <span class="text-gray-400">disabled</span>
-          {{ end }}
-        </td>
-        <td class="px-2 py-1" title="{{ .CheckedAt }}">
-          {{ if .CheckedAt }}{{ relativeTime .CheckedAtTime }}{{ end }}
-        </td>
-      </tr>
-      {{ end }}
-    </tbody>
-  </table>
-  <div class="flex justify-between mt-4">
-    {{ if .PrevPage }}
-    <a href="/?page={{ .PrevPage }}" class="text-blue-700">Previous</a>
-    {{ else }}<span></span>{{ end }}
-    {{ if .NextPage }}
-    <a href="/?page={{ .NextPage }}" class="text-blue-700">Next</a>
-    {{ end }}
-  </div>
-</body>
+        <table class="hidden sm:table w-full text-sm">
+            <thead class="bg-gray-100 sticky top-0">
+                <tr>
+                    <th class="px-2 py-1 text-left w-12">#</th>
+                    <th class="px-2 py-1 text-left">Domain</th>
+                    <th class="px-2 py-1 text-left">Status</th>
+                    <th class="px-2 py-1 text-left">Checked</th>
+                </tr>
+            </thead>
+            <tbody>
+                {{ range .Domains }}
+                <tr class="even:bg-gray-50 hover:bg-gray-100">
+                    <td class="px-2 py-1 text-gray-500">#{{ .Rank }}</td>
+                    <td class="px-2 py-1 font-semibold">
+                        {{ .Base }}<span
+                            class="{{ if .Important }}text-red-600{{ else }}text-gray-400{{ end }}"
+                            >.{{ .TLD }}</span
+                        >
+                    </td>
+                    <td class="px-2 py-1">
+                        {{ if .HasDNSSEC }}
+                        <span
+                            class="inline-flex items-center px-2 py-0.5 rounded-full text-xs font-medium bg-red-100 text-red-600"
+                            >enabled</span
+                        >
+                        {{ else }}
+                        <span class="text-gray-400">disabled</span>
+                        {{ end }}
+                    </td>
+                    <td class="px-2 py-1" title="{{ .CheckedAt }}">
+                        {{ if .CheckedAt }}{{ relativeTime .CheckedAtTime }}{{
+                        end }}
+                    </td>
+                </tr>
+                {{ end }}
+            </tbody>
+        </table>
+        <div class="flex justify-between mt-4">
+            {{ if .PrevPage }}
+            <a href="/?page={{ .PrevPage }}" class="text-blue-700">Previous</a>
+            {{ else }}<span></span>{{ end }} {{ if .NextPage }}
+            <a href="/?page={{ .NextPage }}" class="text-blue-700">Next</a>
+            {{ end }}
+        </div>
+    </body>
 </html>
 {{ end }}


### PR DESCRIPTION
## Summary
- reorder top stats to show Top 100 first
- add subtle links from Top 500 and Top 1000 cards
- give room under the DNSSEC Status heading

## Testing
- `go vet ./...`
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_6857481ba3b8833289bfc143493b6088