### PR TITLE
Limit list results and checkpoint WAL

### DIFF
--- a/main.go
+++ b/main.go
@@ -152,9 +152,10 @@ func loadClasses(db *sql.DB, path string) error {
 
 func listUnclassed(db *sql.DB, w io.Writer) error {
 	const q = `
-		SELECT name FROM domains
-		WHERE class IS NULL OR class = ''
-		ORDER BY rank`
+                SELECT name FROM domains
+                WHERE (class IS NULL OR class = '')
+                AND rank <= 1000
+                ORDER BY rank`
 	rows, err := db.Query(q)
 	if err != nil {
 		return fmt.Errorf("query: %w", err)

--- a/scheduler.go
+++ b/scheduler.go
@@ -173,8 +173,13 @@ func checkDomain(ctx context.Context, db *sql.DB, id int, name string) error {
 
 	_, err = db.ExecContext(ctx,
 		`INSERT INTO dns_checks(domain_id, has_dnssec, error)
-                VALUES(?, ?, ?)`,
+               VALUES(?, ?, ?)`,
 		id, has, errStr,
 	)
+	if err != nil {
+		return err
+	}
+
+	_, err = db.ExecContext(ctx, `PRAGMA wal_checkpoint(TRUNCATE)`)
 	return err
 }


### PR DESCRIPTION
## Summary
- restrict `list-unclassed` to domains ranked 1000 or better
- checkpoint the WAL after each domain check to keep it small

## Testing
- `go vet ./...`
- `go build ./...`


------
https://chatgpt.com/codex/tasks/task_e_6858a4e6b8ac8332a22995f84ad007c1