### PR TITLE
Add htmx-based infinite scroll

### DIFF
--- a/PROJECT.md
+++ b/PROJECT.md
@@ -1,6 +1,6 @@
 # dnssecme-not Project Plan
 
-This document outlines the comprehensive plan for **dnssecme-not**, a Go-based service that tracks DNSSEC adoption among the top domains, backed by SQLite and rendered via a simple Tailwind CSS frontend (no JavaScript).
+This document outlines the comprehensive plan for **dnssecme-not**, a Go-based service that tracks DNSSEC adoption among the top domains, backed by SQLite and rendered via a simple Tailwind CSS frontend with htmx for interactivity.
 
 ## Table of Contents
 1. [Project Overview](#project-overview)
@@ -56,6 +56,7 @@ This document outlines the comprehensive plan for **dnssecme-not**, a Go-based s
 - **Tailwind CSS** for styling (via `tailwindcss` CLI or embedded CDN)
 - **go:embed** (builtin) for bundling static assets
 - **go-dotenv** (`github.com/joho/godotenv`) for `.env` config
+- **htmx** via CDN for minimal dynamic behaviour
 
 ## Task Checklist
 
@@ -87,7 +88,7 @@ This document outlines the comprehensive plan for **dnssecme-not**, a Go-based s
  - [x] Define route for listing domains and their latest DNSSEC status
  - [ ] Add detail view and filtering
 - [x] Integrate Tailwind CSS workflow (build or CDN)
-- [x] Build minimal HTML templates (no JavaScript)
+- [x] Build minimal HTML templates (htmx only)
 - [ ] Come up with a qualitative color scheme (expressed in standard tailwind colors) for classes
 - [ ] Show the classification next to each domain in the list
 - [ ] Add filtering by classification on the index view
@@ -137,7 +138,7 @@ CONCURRENT_WORKERS=10
 The index view uses Tailwind CSS from the CDN. A grid with four columns shows
 rank, domain, DNSSEC status and the last check time. About fifty rows render per
 page with `page` as a query parameter. Status text is colored green or red. The
-layout is responsive and relies on no JavaScript.
+layout is responsive and uses htmx for infinite scroll.
 
 ## Deprecated Tasks
 

--- a/handler_index.go
+++ b/handler_index.go
@@ -41,6 +41,8 @@ func dnssecRatio(ctx context.Context, db *sql.DB, limit int) (float64, error) {
 
 func indexHandler(db *sql.DB) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		hx := r.Header.Get("HX-Request") == "true"
+		trigger := r.Header.Get("HX-Trigger")
 		page := 1
 		if p := r.URL.Query().Get("page"); p != "" {
 			i, err := strconv.Atoi(p)
@@ -140,7 +142,15 @@ func indexHandler(db *sql.DB) http.Handler {
 		if hasNext {
 			data.NextPage = page + 1
 		}
-		err = templates.ExecuteTemplate(w, "index", data)
+		tpl := "index"
+		if hx {
+			if trigger == "more-table" {
+				tpl = "rowsTable"
+			} else if trigger == "more-mobile" {
+				tpl = "rowsMobile"
+			}
+		}
+		err = templates.ExecuteTemplate(w, tpl, data)
 		if err != nil {
 			http.Error(w, err.Error(), http.StatusInternalServerError)
 		}

--- a/templates/index.html
+++ b/templates/index.html
@@ -5,6 +5,7 @@
         <meta charset="utf-8" />
         <title>dnssec-me-not: tracking DNSSEC adoption in top domains</title>
         <link href="/static/style.css" rel="stylesheet" />
+        <script src="https://unpkg.com/htmx.org@1.9.12"></script>
     </head>
     <body class="p-4">
         <h1 class="text-2xl mb-2">DNSSEC Adoption In The Tranco Top 1000</h1>
@@ -40,12 +41,39 @@
             </div>
         </div>
 
-        <div class="sm:hidden space-y-2">
-            {{ range .Domains }}
-            <div class="bg-white p-3 rounded shadow">
-                <p class="text-sm">
-                    <span class="text-gray-500">#{{ .Rank }}</span>
-                    <span class="font-semibold">
+        <div id="mobile-list" class="sm:hidden space-y-2">
+            {{ template "rowsMobile" . }}
+        </div>
+
+        <table class="hidden sm:table w-full text-sm">
+            <thead class="bg-gray-100 sticky top-0">
+                <tr>
+                    <th class="px-2 py-1 text-left w-12">#</th>
+                    <th class="px-2 py-1 text-left">Domain</th>
+                    <th class="px-2 py-1 text-left">Status</th>
+                </tr>
+            </thead>
+            <tbody id="table-list">
+                {{ template "rowsTable" . }}
+            </tbody>
+        </table>
+        <div class="flex justify-between mt-4">
+            {{ if .PrevPage }}
+            <a href="/?page={{ .PrevPage }}" class="text-blue-700">Previous</a>
+            {{ else }}<span></span>{{ end }} {{ if .NextPage }}
+            <a href="/?page={{ .NextPage }}" class="text-blue-700">Next</a>
+            {{ end }}
+        </div>
+    </body>
+</html>
+{{ end }}
+
+{{ define "rowsMobile" }}
+    {{ range .Domains }}
+    <div class="bg-white p-3 rounded shadow">
+        <p class="text-sm">
+            <span class="text-gray-500">#{{ .Rank }}</span>
+            <span class="font-semibold">
                         {{ .Base }}<span
                             class="{{ if .Important }}text-red-600{{ else }}text-gray-400{{ end }}"
                             >.{{ .TLD }}</span
@@ -61,76 +89,72 @@
                         uncategorized
                     </span>
                     {{ end }}
-                </p>
-                <p class="text-xs text-gray-500">
-                    {{ if .HasDNSSEC }}
-                    <span
-                        class="inline-flex items-center px-2 py-0.5 rounded-full text-xs font-medium bg-red-100 text-red-600"
-                        >enabled</span
-                    >
-                    {{ else }}
-                    <span class="text-gray-400">disabled</span>
-                    {{ end }} &bull; {{ if .CheckedAt }}{{ relativeTime
-                    .CheckedAtTime }}{{ end }}
-                </p>
-            </div>
-            {{ end }}
-        </div>
+        </p>
+        <p class="text-xs text-gray-500">
+            {{ if .HasDNSSEC }}
+            <span
+                class="inline-flex items-center px-2 py-0.5 rounded-full text-xs font-medium bg-red-100 text-red-600"
+                >enabled</span
+            >
+            {{ else }}
+            <span class="text-gray-400">disabled</span>
+            {{ end }} &bull; {{ if .CheckedAt }}{{ relativeTime
+            .CheckedAtTime }}{{ end }}
+        </p>
+    </div>
+    {{ end }}
+    {{ if .NextPage }}
+    <div id="more-mobile"
+        hx-get="/?page={{ .NextPage }}"
+        hx-trigger="revealed"
+        hx-swap="outerHTML"
+    ></div>
+    {{ end }}
+{{ end }}
 
-        <table class="hidden sm:table w-full text-sm">
-            <thead class="bg-gray-100 sticky top-0">
-                <tr>
-                    <th class="px-2 py-1 text-left w-12">#</th>
-                    <th class="px-2 py-1 text-left">Domain</th>
-                    <th class="px-2 py-1 text-left">Status</th>
-                </tr>
-            </thead>
-            <tbody>
-                {{ range .Domains }}
-                <tr class="even:bg-gray-50 hover:bg-gray-100">
-                    <td class="px-2 py-1 text-gray-500">#{{ .Rank }}</td>
-                    <td class="px-2 py-1 font-semibold">
-                        {{ .Base }}<span
-                            class="{{ if .Important }}text-red-600{{ else }}text-gray-400{{ end }}"
-                            >.{{ .TLD }}</span
-                        >
-                        {{ if .Class }}
-                        <span
-                            class="ml-2 inline-flex items-center px-2 py-0.5 rounded-full text-xs font-medium {{ classColor .Class }}"
-                            >{{ .Class }}</span
-                        >
-                        {{ else }}
-                        <span class="ml-2 text-xs text-gray-200">(uncategorized)</span>
-                        {{ end }}
-                    </td>
-                    <td class="px-2 py-1">
-                        {{ if .HasDNSSEC }}
-                        <span
-                            class="inline-flex items-center px-2 py-0.5 rounded-full text-xs font-medium bg-red-100 text-red-600"
-                            >enabled</span
-                        >
-                        {{ else }}
-                        <span class="text-gray-400">disabled</span>
-                        {{ end }}
-                        <div
-                            class="text-xs text-gray-500"
-                            title="{{ .CheckedAt }}"
-                        >
-                            {{ if .CheckedAt }} {{ relativeTime .CheckedAtTime
-                            }} {{ end }}
-                        </div>
-                    </td>
-                </tr>
-                {{ end }}
-            </tbody>
-        </table>
-        <div class="flex justify-between mt-4">
-            {{ if .PrevPage }}
-            <a href="/?page={{ .PrevPage }}" class="text-blue-700">Previous</a>
-            {{ else }}<span></span>{{ end }} {{ if .NextPage }}
-            <a href="/?page={{ .NextPage }}" class="text-blue-700">Next</a>
+{{ define "rowsTable" }}
+    {{ range .Domains }}
+    <tr class="even:bg-gray-50 hover:bg-gray-100">
+        <td class="px-2 py-1 text-gray-500">#{{ .Rank }}</td>
+        <td class="px-2 py-1 font-semibold">
+            {{ .Base }}<span
+                class="{{ if .Important }}text-red-600{{ else }}text-gray-400{{ end }}"
+                >.{{ .TLD }}</span
+            >
+            {{ if .Class }}
+            <span
+                class="ml-2 inline-flex items-center px-2 py-0.5 rounded-full text-xs font-medium {{ classColor .Class }}"
+                >{{ .Class }}</span
+            >
+            {{ else }}
+            <span class="ml-2 text-xs text-gray-200">(uncategorized)</span>
             {{ end }}
-        </div>
-    </body>
-</html>
+        </td>
+        <td class="px-2 py-1">
+            {{ if .HasDNSSEC }}
+            <span
+                class="inline-flex items-center px-2 py-0.5 rounded-full text-xs font-medium bg-red-100 text-red-600"
+                >enabled</span
+            >
+            {{ else }}
+            <span class="text-gray-400">disabled</span>
+            {{ end }}
+            <div
+                class="text-xs text-gray-500"
+                title="{{ .CheckedAt }}"
+            >
+                {{ if .CheckedAt }} {{ relativeTime .CheckedAtTime }} {{ end }}
+            </div>
+        </td>
+    </tr>
+    {{ end }}
+    {{ if .NextPage }}
+    <tr id="more-table"
+        hx-get="/?page={{ .NextPage }}"
+        hx-trigger="revealed"
+        hx-swap="outerHTML"
+    >
+        <td colspan="3"></td>
+    </tr>
+    {{ end }}
 {{ end }}


### PR DESCRIPTION
## Summary
- integrate htmx via CDN
- add partial templates for mobile and table domain lists
- serve partial templates when requested by htmx
- describe htmx usage in PROJECT.md

## Testing
- `go vet ./...`
- `go build ./...`


------
https://chatgpt.com/codex/tasks/task_e_6858bb1ee00883329c5145717fd99935