### PR TITLE
Simplify DS lookup result

### DIFF
--- a/PROJECT.md
+++ b/PROJECT.md
@@ -80,8 +80,10 @@ This document outlines the comprehensive plan for **dnssecme-not**, a Go-based s
  - [ ] Implement rate-limited DS record lookup (using `miekg/dns` + `rate.Limiter`)
  - [x] Randomly select from names in the top list to re-check based on when the last check was.
  - [x] Write background scheduler (ticker) for periodic checks
-- [ ] Handle failures & retries (backoff, logging)
-- [ ] Add a command-line one-time check that updates the whole list interactively.
+ - [ ] Handle failures & retries (backoff, logging)
+ - [x] Ignore error results when computing status changes
+ - [x] Query two random resolvers for DS lookups
+ - [ ] Add a command-line one-time check that updates the whole list interactively.
 
 ### Web Server & Frontend
 - [x] Implement HTTP server using `net/http`

--- a/handler_changes.go
+++ b/handler_changes.go
@@ -14,19 +14,20 @@ type changeRow struct {
 
 func (srv *DNSSECMeNot) handleChanges(w http.ResponseWriter, r *http.Request) {
 	rows, err := srv.db.Query(`
-                        SELECT d.name, c.checked_at, c.has_dnssec
-                        FROM (
-                                SELECT domain_id, checked_at, has_dnssec,
-                                       LAG(has_dnssec) OVER (
-                                               PARTITION BY domain_id
-                                               ORDER BY checked_at
-                                       ) AS prev
-                                FROM dns_checks
-                        ) c
-                        JOIN domains d ON d.id = c.domain_id
-                        WHERE c.prev IS NULL OR c.prev != c.has_dnssec
-                        ORDER BY c.checked_at DESC
-                        LIMIT 200`)
+                       SELECT d.name, c.checked_at, c.has_dnssec
+                       FROM (
+                               SELECT domain_id, checked_at, has_dnssec, error,
+                                      LAG(has_dnssec) OVER (
+                                              PARTITION BY domain_id
+                                              ORDER BY checked_at
+                                      ) AS prev
+                               FROM dns_checks
+                       ) c
+                       JOIN domains d ON d.id = c.domain_id
+                       WHERE (c.error IS NULL OR c.error = '') AND
+                             (c.prev IS NULL OR c.prev != c.has_dnssec)
+                       ORDER BY c.checked_at DESC
+                       LIMIT 200`)
 	if err != nil {
 		http.Error(w, err.Error(), http.StatusInternalServerError)
 		return


### PR DESCRIPTION
## Summary
- return DS answer from one resolver when resolvers agree
- switch random functions to `math/rand/v2`

## Testing
- `go vet ./...`
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_6859e84a62188332b817f8677ffef376